### PR TITLE
Workaround for "GetAll" methods

### DIFF
--- a/ConektaLib.cs
+++ b/ConektaLib.cs
@@ -439,7 +439,7 @@ namespace Conekta {
 
             client.ExecuteAsync(GetRequest(url, Method.GET, obj, parameters), response => {
                 var str = response.Content;
-                var baseObject = str.FromJson<BaseObject>();
+                var baseObject = typeof(T).IsArray ? str.FromJson<BaseObject[]>()[0] : str.FromJson<BaseObject>();
 
                 if (response.StatusCode == HttpStatusCode.Unauthorized)
                     tcs.SetException(new InvalidKeyException(baseObject.Message));


### PR DESCRIPTION
Currently it crashed when trying to parse the response to a BaseObject when receiving object collections. This patch checks if T is an array and if it is, parses the response to a BaseObject array and uses the first element as the baseObject.